### PR TITLE
include numeric for accumulate

### DIFF
--- a/include/warehouse_ros_sqlite/client.h
+++ b/include/warehouse_ros_sqlite/client.h
@@ -341,9 +341,9 @@ public:
     return;
   }
 
-  std::auto_ptr<DBClientCursor> query(const std::string ns, const sqlite::Query query)
+  std::unique_ptr<DBClientCursor> query(const std::string ns, const sqlite::Query query)
   {
-    std::auto_ptr<DBClientCursor> c(new DBClientCursor(this, ns , query.obj));
+    std::unique_ptr<DBClientCursor> c(new DBClientCursor(this, ns , query.obj));
 
     std::string cmd = "SELECT document FROM \"" + ns + "\" " + createSQLQuery(query);
     if ( query.obj.hasField("$orderby") ) {

--- a/include/warehouse_ros_sqlite/client.h
+++ b/include/warehouse_ros_sqlite/client.h
@@ -31,6 +31,7 @@
 #define WAREHOUSE_ROS_SQLITE_CLIENT_H
 
 #include <stack>
+#include <numeric>
 
 #include <ros/ros.h>
 #include <bson.h>

--- a/include/warehouse_ros_sqlite/query_results.h
+++ b/include/warehouse_ros_sqlite/query_results.h
@@ -51,7 +51,7 @@ namespace warehouse_ros_sqlite
 
 // To avoid some const-correctness issues we wrap SQLite's returned auto_ptr in
 // another pointer
-typedef std::auto_ptr<sqlite::DBClientCursor> Cursor;
+typedef std::unique_ptr<sqlite::DBClientCursor> Cursor;
 typedef boost::shared_ptr<Cursor> CursorPtr;
 
 class SQLiteResultIterator : public warehouse_ros::ResultIteratorHelper

--- a/src/database_connection.cpp
+++ b/src/database_connection.cpp
@@ -112,7 +112,7 @@ string SQLiteDatabaseConnection::messageType(const string& db, const string& col
   if (!isConnected())
     throw warehouse_ros::DbConnectException("Cannot look up metatable.");
   const string meta_ns = db+".ros_message_collections";
-  std::auto_ptr<sqlite::DBClientCursor> cursor = conn_->query(meta_ns, BSON("name" << coll));
+  std::unique_ptr<sqlite::DBClientCursor> cursor = conn_->query(meta_ns, BSON("name" << coll));
   bson::BSONObj obj = cursor->next();
   return obj.getStringField("type");
 }


### PR DESCRIPTION
I confirmed that `warehouse_ros_sqlite` works in Ubuntu 18.04 / ROS Melodic with latest master branch of MoveIt. gcc version is 7.4.0. Need following fix.

1. Fix for the following error.
```
/home/leus/ws_moveit/src/warehouse_ros_sqlite/include/warehouse_ros_sqlite/client.h:332:17: error: ‘accumulate’ is not a member of ‘std’
     cmd += std::accumulate(std::begin(metastring), std::end(metastring), std::string(),
```

2. Use `std::unique_ptr` instead of `std::auto_ptr` to avoid the following warning (ref: https://stackoverflow.com/q/40893636 ). `std::unique_ptr` also is used in many places of moveit sources.
```
/home/leus/ws_moveit/src/warehouse_ros_sqlite/include/warehouse_ros_sqlite/client.h:343:8: warning: ‘template<class> class std::auto_ptr’ is deprecated [-Wdeprecated-declarations]
   std::auto_ptr<DBClientCursor> query(const std::string ns, const sqlite::Query query)
        ^~~~~~~~
```
